### PR TITLE
Simplify split-once to make lib bb compatible again

### DIFF
--- a/src/version_clj/split.cljc
+++ b/src/version_clj/split.cljc
@@ -1,7 +1,7 @@
 (ns ^:no-doc version-clj.split
-  (:require [version-clj.normalize :as normalize]
-            [version-clj.qualifiers :refer [default-qualifiers]]
-            [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [version-clj.normalize :as normalize]
+            [version-clj.qualifiers :refer [default-qualifiers]]))
 
 ;; ## Desired Results
 ;;
@@ -21,19 +21,7 @@
 (defn- split-once
   "Helper to split exactly once on the given regex."
   [re s]
-  #?(:clj  (let [m (re-matcher re s)]
-             (if (.find m)
-               (let [idx (.start m)
-                     len (- (.end m) idx)]
-                 [(subs s 0 idx)
-                  (subs s (+ idx len))])
-               [s]))
-     :cljs (if-let [parts (.exec re s)]
-             (let [idx (.-index parts)
-                   len (count (aget ^array parts 0))]
-               [(subs s 0 idx)
-                (subs s (+ idx len))])
-             [s])))
+  (string/split s re 2))
 
 (defn- split-all
   "Helper to recursively apply split points."


### PR DESCRIPTION
@xsc This simplifies the `split-once` function so I'm able to run this library with babashka again.

The version that is tested in CI with babashka itself is 0.1.2.

Also see:
https://github.com/babashka/babashka/blob/master/doc/projects.md#version-clj