### PR TITLE
Sanity check for string splitting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,9 @@
                  [org.clojure/clojurescript "1.10.773" :scope "provided"]
                  [com.google.code.findbugs/jsr305 "3.0.2" :scope "provided"]]
 
-  :profiles {:kaocha
+  :profiles {:dev
+             {:global-vars {*warn-on-reflection* true}}
+             :kaocha
              {:dependencies [[lambdaisland/kaocha "1.0.732"
                               :exclusions [org.clojure/spec.alpha]]
                              [lambdaisland/kaocha-cljs "0.0-71"

--- a/src/version_clj/split.cljc
+++ b/src/version_clj/split.cljc
@@ -19,7 +19,15 @@
   (string/split s split-point))
 
 (defn- split-once
-  "Helper to split exactly once on the given regex."
+  "Helper to split exactly once on the given regex. This is NOT THE SAME as
+   `(string/split s re 2)` since:
+
+   - splitting at the beginning will yield `[\"\" \"...\"]` where `string/split`
+     does not split at all,
+   - splitting with lookahead/lookbehind seems broken in ClojureScript.
+
+   See the `t-split-once-sanity-check` testcase for examples that yield
+   surprising results with `string/split`."
   [re s]
   #?(:clj  (let [m (re-matcher re s)]
              (if (.find m)

--- a/test/version_clj/split_test.cljc
+++ b/test/version_clj/split_test.cljc
@@ -3,6 +3,15 @@
                :cljs [cljs.test :refer-macros [deftest testing are is]])
             [version-clj.split :refer [version->seq]]))
 
+(deftest t-split-once-sanity-check
+  (let [split-once @#'version-clj.split/split-once
+        rx #"(^|(?<=\d)|-)(?=alpha)"]
+    (are [in out] (= out (split-once rx in))
+         "1-alpha2.2"             ["1" "alpha2.2"]
+         "alpha"                  ["" "alpha"]
+         "1alpha"                 ["1" "alpha"]
+         "0.0.3-alpha.8+oryOS.15" ["0.0.3" "alpha.8+oryOS.15"])))
+
 (deftest t-split
   (are [version v] (= v (version->seq version))
        "1.0.0"                  [[1 0 0]]


### PR DESCRIPTION
`split-once` is a delicate function that behaves slightly different from `string/split` (which in itself behaves differently between Clojure/ClojureScript). This adds a sanity check testcase to illustrate that behaviour.