### PR TITLE
Fix false positive with comparing prefixed versions

### DIFF
--- a/src/version_clj/split.cljc
+++ b/src/version_clj/split.cljc
@@ -74,6 +74,10 @@
   "Split at the dash, if followed by a letter or only numbers."
   #"(?i)-(?=[^\d]|\d+$)")
 
+(def ^:const SPLIT-PREFIX
+  "Split a given string into char-only prefix and rest parts."
+  #"(?<=^\D+)(?=\d)")
+
 ;; ## Splitting Algorithm
 
 ;; ### Splitting a plain version
@@ -87,7 +91,7 @@
 (defn- split-version
   "Split a version that has already been separated from its qualifier."
   [version]
-  (split-all [SPLIT-DOT SPLIT-DASH SPLIT-COMPOUND] version))
+  (split-all [SPLIT-PREFIX SPLIT-DOT SPLIT-DASH SPLIT-COMPOUND] version))
 
 ;; ### Splitting a plain qualifier
 ;;

--- a/test/version_clj/compare_test.cljc
+++ b/test/version_clj/compare_test.cljc
@@ -70,4 +70,13 @@
        ;; Some more zero-extension Tests
        "1-SNAPSHOT"      "1.0-SNAPSHOT"    0
        "1-alpha"         "1-alpha0"        0
+
+       ;; Prefixed versions
+       "v1"              "v1"              0
+       "v1"              "v2"             -1
+       "v1"              "v1.1"           -1
+       "v1.1"            "v1.2"           -1
+       "v1.1"            "v2"             -1
+       "alpaca1.0"       "bermuda1.0"     -1
        ))
+

--- a/test/version_clj/split_test.cljc
+++ b/test/version_clj/split_test.cljc
@@ -35,6 +35,10 @@
        "0.5.0-alpha.1"          [[0 5 0] ["alpha" 1]]
        "0.5.0-alpha.1"          [[0 5 0] ["alpha" 1]]
        "0.0.3-alpha.8+oryOS.15" [[0 0 3] ["alpha" [8 "+oryos"] 15]]
+       "v1"                     [["v" 1]]
+       "v1.1"                   [["v" [1 1]]]
+       "ver1"                   [["ver" 1]]
+       "ver1.1"                 [["ver" [1 1]]]
        ))
 
 (deftest t-split-without-qualifiers


### PR DESCRIPTION
I'm not sure this is the right fix, so feel free to reject if you don't like :)

I found a false positive with comparing prefixed versions such as `v1.1`.
This PR fixes the below false positive.

### Expected behavior

```clj
(version-clj.core/version-compare "v1.1" "v2") ;; => -1
```

### Actual behavior

```clj
(version-clj.core/version-compare "v1.1" "v2") ;; => 1
```