### PR TITLE
docs: add babashka compatible badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Documentation](https://cljdoc.org/badge/version-clj/version-clj)](https://cljdoc.org/d/version-clj/version-clj/CURRENT)
 ![CI](https://github.com/xsc/version-clj/workflows/CI/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/xsc/version-clj/branch/master/graph/badge.svg?token=xmrXrhA6Z7)](https://codecov.io/gh/xsc/version-clj)
+[![bb compatible](https://raw.githubusercontent.com/babashka/babashka/master/logo/badge.svg)](https://babashka.org)
 
 __version-clj__ is a Clojure &amp; ClojureScript library for analysis and
 comparison of artifact version numbers. It originated as a comparison mechanism


### PR DESCRIPTION
It's very nice that version-clj can be used from babashka as a dependency, add a badge to indicate such.