### PR TITLE
Add "release" as a qualifier

### DIFF
--- a/src/version_clj/qualifiers.cljc
+++ b/src/version_clj/qualifiers.cljc
@@ -7,4 +7,4 @@
     "milestone" 2 "m"         2
     "rc"        3 "cr"        3
     "snapshot"  5
-    ""          6 "final"     6 "stable"    6 })
+    ""          6 "final"     6 "stable"    6 "release"   6})

--- a/test/version_clj/compare_test.cljc
+++ b/test/version_clj/compare_test.cljc
@@ -30,6 +30,8 @@
        "1.0.0-beta"     "1.0.0-alpha"     1
        "1.0.0-alpaca"   "1.0.0-beta"     -1
        "1.0.0-final"    "1.0.0-milestone" 1
+       "1.0.0-snapshot" "1.0.0-release"  -1
+       "1.0.0-release"  "1.0.0-snapshot"  1
 
        ;; Qualifier/Numeric Comparison
        "1.0.0-alpha1"   "1.0.0-alpha2"   -1


### PR DESCRIPTION
### What I did

As title says.

### Expected behavior

[Lettuce](https://github.com/redis/lettuce) has `RELEASE` and `M` as version qualifiers.

* https://github.com/redis/lettuce/releases/tag/6.4.0.RELEASE
* https://github.com/redis/lettuce/releases/tag/6.4.0.M1

It seems natural to assume that `RELEASE` is considered a newer version than `M1`.

### Actual behavior

```clojure
(version-clj.core/version-compare "6.4.0.M1" "6.4.0.RELEASE") ;; => 1
```